### PR TITLE
feat(fixtures): support for mongodb embeddables

### DIFF
--- a/packages/fixtures/src/MetadataStore.ts
+++ b/packages/fixtures/src/MetadataStore.ts
@@ -5,7 +5,12 @@ import {
   PropertyMetadata,
   DefaultMetadataStore,
 } from 'class-fixtures-factory';
-import { MikroORM, Utils, EntityMetadata } from '@mikro-orm/core';
+import {
+  MikroORM,
+  Utils,
+  EntityMetadata,
+  ReferenceType,
+} from '@mikro-orm/core';
 
 export class MetadataStore extends BaseMetadataStore {
   private defaultStore = new DefaultMetadataStore(true);
@@ -32,6 +37,12 @@ export class MetadataStore extends BaseMetadataStore {
           );
           if (prop.primary) return null;
           if (prop.type === 'method') return null;
+          if (Array.isArray(prop.embedded)) {
+            const parent = meta.properties[prop.embedded[0]];
+            if (parent.reference === ReferenceType.EMBEDDED && parent.object) {
+              return null;
+            }
+          }
           return <PropertyMetadata>{
             name: prop.name,
             type: defaultMetaProp?.typeFromDecorator

--- a/packages/fixtures/test/entities/profile.entity.ts
+++ b/packages/fixtures/test/entities/profile.entity.ts
@@ -1,0 +1,8 @@
+import { Embeddable, Property } from '@mikro-orm/core';
+
+@Embeddable()
+export class Profile {
+  @Property() firstName!: string;
+  @Property() lastName!: string;
+  @Property() emailAddress!: string;
+}

--- a/packages/fixtures/test/entities/user.entity.ts
+++ b/packages/fixtures/test/entities/user.entity.ts
@@ -1,0 +1,8 @@
+import { Embedded, Entity } from '@mikro-orm/core';
+import { BaseEntity } from './base.entity';
+import { Profile } from './profile.entity';
+
+@Entity()
+export class User extends BaseEntity {
+  @Embedded({ entity: () => Profile, object: true }) profile!: Profile;
+}

--- a/packages/fixtures/test/mikro-orm.config.ts
+++ b/packages/fixtures/test/mikro-orm.config.ts
@@ -13,6 +13,8 @@ import {
   Book2,
   Address2,
 } from './entities/author-with-customization';
+import { Profile } from './entities/profile.entity';
+import { User } from './entities/user.entity';
 
 export default <Options>{
   metadataProvider: TsMorphMetadataProvider,
@@ -28,6 +30,8 @@ export default <Options>{
     AuthorWithCustomization,
     Book2,
     Address2,
+    User,
+    Profile,
   ],
   dbName: 'test.db',
   type: 'sqlite',

--- a/packages/fixtures/test/temp/Profile.ts.json
+++ b/packages/fixtures/test/temp/Profile.ts.json
@@ -1,0 +1,69 @@
+{
+  "data": {
+    "propertyOrder": {},
+    "properties": {
+      "firstName": {
+        "name": "firstName",
+        "reference": "scalar",
+        "getter": false,
+        "setter": false,
+        "type": "string"
+      },
+      "lastName": {
+        "name": "lastName",
+        "reference": "scalar",
+        "getter": false,
+        "setter": false,
+        "type": "string"
+      },
+      "emailAddress": {
+        "name": "emailAddress",
+        "reference": "scalar",
+        "getter": false,
+        "setter": false,
+        "type": "string"
+      }
+    },
+    "props": [
+      {
+        "name": "firstName",
+        "reference": "scalar",
+        "getter": false,
+        "setter": false,
+        "type": "string"
+      },
+      {
+        "name": "lastName",
+        "reference": "scalar",
+        "getter": false,
+        "setter": false,
+        "type": "string"
+      },
+      {
+        "name": "emailAddress",
+        "reference": "scalar",
+        "getter": false,
+        "setter": false,
+        "type": "string"
+      }
+    ],
+    "primaryKeys": [],
+    "filters": {},
+    "hooks": {},
+    "indexes": [],
+    "uniques": [],
+    "className": "Profile",
+    "path": "./test/entities/profile.entity.ts",
+    "name": "Profile",
+    "embeddable": true,
+    "abstract": false,
+    "constructorParams": [],
+    "toJsonParams": [],
+    "useCache": true,
+    "relations": [],
+    "collection": "profile"
+  },
+  "origin": "./test/entities/profile.entity.ts",
+  "hash": "250bb9ee472a9fd9864259db6090675e",
+  "version": "4.5.1"
+}

--- a/packages/fixtures/test/temp/User.ts.json
+++ b/packages/fixtures/test/temp/User.ts.json
@@ -1,0 +1,41 @@
+{
+  "data": {
+    "propertyOrder": {},
+    "properties": {
+      "profile": {
+        "name": "profile",
+        "type": "Profile",
+        "reference": "embedded",
+        "object": true,
+        "prefix": true
+      }
+    },
+    "props": [
+      {
+        "name": "profile",
+        "type": "Profile",
+        "reference": "embedded",
+        "object": true,
+        "prefix": true
+      }
+    ],
+    "primaryKeys": [],
+    "filters": {},
+    "hooks": {},
+    "indexes": [],
+    "uniques": [],
+    "className": "User",
+    "path": "./test/entities/user.entity.ts",
+    "name": "User",
+    "abstract": false,
+    "constructorParams": [],
+    "toJsonParams": [],
+    "extends": "BaseEntity",
+    "useCache": true,
+    "relations": [],
+    "collection": "user"
+  },
+  "origin": "./test/entities/user.entity.ts",
+  "hash": "9c16b52762f9d4c922a0faa76b82a775",
+  "version": "4.5.1"
+}


### PR DESCRIPTION
 - works with the `object: true` option
 - does not include support for the `array: true` option

TL;DR: @mikro-resources/fixtures now respects the `object: true` option when generating properties for embeddables (which is commonly used for mongodb subdocuments).

However, I may need some guidance on how to generate an array of subdocuments, which I have not been able to figure out.