### PR TITLE
Fix entity typing

### DIFF
--- a/packages/fixtures/src/FactoryResultWrapper.ts
+++ b/packages/fixtures/src/FactoryResultWrapper.ts
@@ -2,11 +2,9 @@ import { FactoryResult, FixtureFactory } from 'class-fixtures-factory';
 import { EntityClass } from '@mikro-orm/core/typings';
 import { MikroORM } from '@mikro-orm/core';
 
-type DeepPartial<T> = T extends unknown
-  ? unknown
-  : {
-      [P in keyof T]?: DeepPartial<T[P]>;
-    };
+type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>;
+};
 
 export class FactoryResultWrapper<T> {
   private input?: DeepPartial<T>;


### PR DESCRIPTION
I found there is a bug with the `factory.make().with()` method: no matter which entity I feed to the `make()` method, the `input` for `with()` will be of `unknown` type.

This is because `DeepPartial<T>` will be equal to `unknown` if `T extends unknown`. As far as I can tell, any class is counted as extending unknown.